### PR TITLE
Loading Indicator

### DIFF
--- a/src/components/LoadingIndicator.css
+++ b/src/components/LoadingIndicator.css
@@ -1,0 +1,68 @@
+/* Taken from https://loading.io/css/ */
+.lds-grid {
+    display: inline-block;
+    position: relative;
+    width: 80px;
+    height: 80px;
+}
+.lds-grid div {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: #000;
+    animation: lds-grid 1.2s linear infinite;
+}
+.lds-grid div:nth-child(1) {
+    top: 8px;
+    left: 8px;
+    animation-delay: 0s;
+}
+.lds-grid div:nth-child(2) {
+    top: 8px;
+    left: 32px;
+    animation-delay: -0.4s;
+}
+.lds-grid div:nth-child(3) {
+    top: 8px;
+    left: 56px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(4) {
+    top: 32px;
+    left: 8px;
+    animation-delay: -0.4s;
+}
+.lds-grid div:nth-child(5) {
+    top: 32px;
+    left: 32px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(6) {
+    top: 32px;
+    left: 56px;
+    animation-delay: -1.2s;
+}
+.lds-grid div:nth-child(7) {
+    top: 56px;
+    left: 8px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(8) {
+    top: 56px;
+    left: 32px;
+    animation-delay: -1.2s;
+}
+.lds-grid div:nth-child(9) {
+    top: 56px;
+    left: 56px;
+    animation-delay: -1.6s;
+}
+@keyframes lds-grid {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import "./LoadingIndicator.css";
 
 export default function LoadingIndicator() {
-    console.debug('loading indicator');
     return (<div className="lds-grid">
         <div />
         <div />

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import "./LoadingIndicator.css";
+
+export default function LoadingIndicator() {
+    console.debug('loading indicator');
+    return (<div className="lds-grid">
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+    </div>)
+}

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -7,6 +7,7 @@ import { LinkContainer } from "react-router-bootstrap";
 import { useAppContext } from "../libs/contextLib";
 import { onError } from "../libs/errorLib";
 import { loadNotes, saveNote } from "../libs/apiLib";
+import LoadingIndicator from "../components/LoadingIndicator";
 import NoteFilter from "../components/NoteFilter";
 import "./Home.css";
 
@@ -118,7 +119,7 @@ export default function Home() {
     return (
       <div className="notes">
         <h2 className="pb-3 mt-4 mb-3 border-bottom">Your Notes</h2>
-        <ListGroup>{!isLoading && renderNotesList()}</ListGroup>
+        <ListGroup>{isLoading ? <LoadingIndicator /> : renderNotesList()}</ListGroup>
       </div>
     );
   }

--- a/src/containers/Notes.js
+++ b/src/containers/Notes.js
@@ -3,6 +3,7 @@ import Form from "react-bootstrap/Form";
 import { Storage } from "aws-amplify";
 import { useParams, useHistory } from "react-router-dom";
 import LoaderButton from "../components/LoaderButton";
+import LoadingIndicator from "../components/LoadingIndicator";
 import { onError } from "../libs/errorLib";
 import { s3Upload } from "../libs/awsLib";
 import { deleteNote, loadNote, saveNote } from "../libs/apiLib";
@@ -15,6 +16,7 @@ export default function Notes() {
   const history = useHistory();
   const [note, setNote] = useState(null);
   const [content, setContent] = useState("");
+  const [isLoadingForViewing, setIsLoadingForViewing] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -33,6 +35,7 @@ export default function Notes() {
       } catch (e) {
         onError(e);
       }
+      setIsLoadingForViewing(false);
     }
 
     onLoad();
@@ -106,7 +109,7 @@ export default function Notes() {
 
   return (
     <div className="Notes">
-      {note && (
+      {isLoadingForViewing ? <LoadingIndicator /> : note && (
         <Form onSubmit={handleSubmit}>
           <Form.Group controlId="content">
             <Form.Control


### PR DESCRIPTION
This addresses #3.  A simple, CSS loading indicator is added to the home page when loading all notes and during find/replace as well as to the note viewer page.